### PR TITLE
Fixed Music Bug

### DIFF
--- a/Game.js
+++ b/Game.js
@@ -861,9 +861,11 @@ function updateGameArea() {
 				//animate coin score board
 				gameArea.coinScoreActiveTime = 0;
 				gameArea.coinScoreInterval = setInterval(flashCoinScore, 150);
-				coinpickup_audio=document.getElementById("coinpickup")
-				coinpickup.autoplay = true;
-				coinpickup.load();
+				if(!musicMuted){
+					coinpickup_audio=document.getElementById("coinpickup")
+					coinpickup.autoplay = true;
+					coinpickup.load();
+				}
 			}else{
 				coins[i].rotation();
 			}


### PR DESCRIPTION
When the mute button was on, the coin sound still played when you would pick up coins.

I changed the JS to check if the music was not muted, and then it would play if it was not muted.